### PR TITLE
fix: download failing because non existing dir

### DIFF
--- a/WDM.ahk
+++ b/WDM.ahk
@@ -7,7 +7,7 @@ Class RunDriver
 	__New(Location,Parameters:= "--port=9515")
 	{
 		SplitPath, Location,Name,Dir,,DriverName
-		this.Dir := Dir
+		this.Dir := Dir ? Dir : A_ScriptDir
 		this.exe := Name
 		this.param := Parameters
 		This.Target := Location " " chr(34) Parameters chr(34)


### PR DESCRIPTION
When not specifying a location for the driver the download was failing and I noticed it was because the "Dir" variable was empty.

Set the current script directory as the default to fix the issue.