### PR TITLE
Fix ff binary Location issue

### DIFF
--- a/Rufaydium.ahk
+++ b/Rufaydium.ahk
@@ -91,12 +91,15 @@ Class Rufaydium
 		k := this.Send( this.DriverUrl "/session","POST",this.capabilities.cap,1)
 		if k.error
 		{
-			if(k.message = "binary is not a Firefox executable")
+			if(k.message = "binary is not a Firefox executable")  
 			{
-				ffbinary := A_ProgramFiles "\Mozilla Firefox\firefox.exe"
-				if A_Is64bitOS
-					ffbinary := RegExReplace(ffbinary, " (x86)")
-				if fileexist(ffbinary)
+				; its all in my mind not tested, 32/64ahk 64OS 32/64ff broken down in simple three step logic
+				ffbinary := A_ProgramFiles "\Mozilla Firefox\firefox.exe" ; check ff in default location, cover all 32AHKFFOS, 64AHKFFOS
+				if !FileExist(ffbinary)
+					ffbinary := RegExReplace(ffbinary, " (x86)") ; in case 64OS 32AHK 64FF checking 64ff loc
+				else if !FileExist(ffbinary)
+					ffbinary := A_ProgramFiles " (x86)\Mozilla Firefox\firefox.exe" ; in case 64OS has 64ahk checking 32ff loc
+				else
 				{
 					msgbox,48,Rufaydium WebDriver Support,% k.message "`n`nDriver is unable to locate firefox binary and, Rufaydium is also unabel to detect FF default location`n`n if you see this msg in loop please report bug" 
 					return

--- a/Rufaydium.ahk
+++ b/Rufaydium.ahk
@@ -91,10 +91,21 @@ Class Rufaydium
 		k := this.Send( this.DriverUrl "/session","POST",this.capabilities.cap,1)
 		if k.error
 		{
-			
-			if(k.error = "session not created")
+			if(k.message = "binary is not a Firefox executable")
 			{
-				
+				ffbinary := A_ProgramFiles "\Mozilla Firefox\firefox.exe"
+				if A_Is64bitOS
+					ffbinary := RegExReplace(ffbinary, " (x86)")
+				if fileexist(ffbinary)
+				{
+					msgbox,48,Rufaydium WebDriver Support,% k.message "`n`nDriver is unable to locate firefox binary and, Rufaydium is also unabel to detect FF default location`n`n if you see this msg in loop please report bug" 
+					return
+				} 
+				this.capabilities.Setbinary(ffbinary)
+				return This.NewSession()
+			}
+			else if RegExMatch(k.message,"version ([\d.]+).*\n.*version is (\d+.\d+.\d+)")
+			{
 				MsgBox, 52,Rufaydium WebDriver Support,% k.message "`n`nPlease Press Yes to download latest driver"
 				IfMsgBox Yes
 				{
@@ -105,12 +116,15 @@ Class Rufaydium
 						Msgbox,64,Rufaydium WebDriver Support,Unable to download driver`nRufaydium exitting
 						Exitapp
 					}
+					This.Driver := new RunDriver(i,This.Driver.Param)
+					return This.NewSession()
 				}
-				This.Driver := new RunDriver(i,This.Driver.Param)
-				return This.NewSession()
 			}
-			msgbox, 48,Rufaydium WebDriver Support Error,% k.error "`n`n" k.message
-			return k
+			else
+			{
+				msgbox, 48,Rufaydium WebDriver Support Error,% k.error "`n`n" k.message
+				return k
+			} 
 		}
 		window := []
 		window.Name := This.driver.Name


### PR DESCRIPTION
A_ProgramFiles return x86 program Files location when OS is 64 bit and AHK is 64 bit, we can install Firefox 32/64 bit, sometimes with unknown reason Gecko driver fails read the registry and fail to find Firefox binary, this issue have been fixed in this merge.