### PR TITLE
[AHKv2]Fix Findelements, add session.Title

### DIFF
--- a/Session.ahk
+++ b/Session.ahk
@@ -102,6 +102,11 @@
 	{
 		get => this.Send("source","GET",0,1)
 	}
+	
+	Title
+	{
+		get => this.Send("title","GET")
+	}
 
 	Cookies[CookieMAP]
 	{
@@ -159,13 +164,13 @@
 	findelements(u,v)
 	{
 		e := []
-		for k, element in this.Send("elements","POST",map("using",u,"value",v),1)
+		for k, elements in this.Send("elements","POST",map("using",u,"value",v),1)
 		{
-			for i, elementid in element
-				e[k-1] := Element(this.address "/element/" elementid,i)
+			for i, elementid in elements
+				e.InsertAt(k-1,Element(this.address "/element/" elementid,i))
 		}
 
-		if e.count() > 0
+		if e.Length > 0
 			return e
 		return 0
 	}


### PR DESCRIPTION
I think I fixed findelements method in Elements.ahk
I think part of the problem was that the outer loop was using Element as map value, and the innermost loop was using walling Element class, so I changed the map to Elements.
Then I used insertat to push to the e array, since the original way caused errors.
